### PR TITLE
🧩 remove blacklisted countries from selection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": ">=7.3",
-    "spryker/glossary": "^3.7.0",
+    "php": ">=7.2",
+    "spryker/glossary": "^3.8.0",
     "spryker/customer": "^7.27.0",
-    "spryker-shop/checkout-page": "^3.0.0",
+    "spryker-shop/checkout-page": "^3.7.0",
     "fond-of-spryker/country": "dev-feature/paypal-refund || dev-spryker_upgrade || ^1.0.0",
     "spryker-shop/customer-page": "^2.7.1",
     "spryker-shop/home-page": "^1.0.0",
-    "spryker/shipment": "^8.0.0",
+    "spryker/shipment": "^8.0.2",
     "spryker/quote": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "fond-of-oryx/product-country-restriction-checkout-connector": "^1.1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
   "require": {
     "php": ">=7.2",
     "spryker/glossary": "^3.8.0",
-    "spryker/customer": "^7.27.0",
-    "spryker-shop/checkout-page": "^3.7.0",
+    "spryker/customer": "^7.26.5",
+    "spryker-shop/checkout-page": "<3.19.0",
     "fond-of-spryker/country": "dev-feature/paypal-refund || dev-spryker_upgrade || ^1.0.0",
     "spryker-shop/customer-page": "^2.7.1",
     "spryker-shop/home-page": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": ">=7.2",
     "spryker/glossary": "^3.8.0",
     "spryker/customer": "^7.26.5",
-    "spryker-shop/checkout-page": "3.13.0",
+    "spryker-shop/checkout-page": "<3.19.0",
     "fond-of-spryker/country": "dev-feature/paypal-refund || dev-spryker_upgrade || ^1.0.0",
     "spryker-shop/customer-page": "^2.7.1",
     "spryker-shop/home-page": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=7.2",
     "spryker/glossary": "^3.8.0",
-    "spryker/customer": "^7.26.5",
+    "spryker/customer": "^7.27.0",
     "spryker-shop/checkout-page": "^3.7.0",
     "fond-of-spryker/country": "dev-feature/paypal-refund || dev-spryker_upgrade || ^1.0.0",
     "spryker-shop/customer-page": "^2.7.1",

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,10 @@
       "Generated\\": "src/Generated/",
       "Orm\\": "src/Orm/"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": ">=7.2",
     "spryker/glossary": "^3.8.0",
     "spryker/customer": "^7.26.5",
-    "spryker-shop/checkout-page": "<3.19.0",
+    "spryker-shop/checkout-page": "3.13.0",
     "fond-of-spryker/country": "dev-feature/paypal-refund || dev-spryker_upgrade || ^1.0.0",
     "spryker-shop/customer-page": "^2.7.1",
     "spryker-shop/home-page": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": ">=7.2",
-    "spryker/glossary": "^3.8.0",
+    "php": ">=7.3",
+    "spryker/glossary": "^3.7.0",
     "spryker/customer": "^7.27.0",
-    "spryker-shop/checkout-page": "^3.7.0",
+    "spryker-shop/checkout-page": "^3.0.0",
     "fond-of-spryker/country": "dev-feature/paypal-refund || dev-spryker_upgrade || ^1.0.0",
     "spryker-shop/customer-page": "^2.7.1",
     "spryker-shop/home-page": "^1.0.0",
-    "spryker/shipment": "^8.0.2",
+    "spryker/shipment": "^8.0.0",
     "spryker/quote": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "fond-of-oryx/product-country-restriction-checkout-connector": "^1.1.0"
   },

--- a/src/FondOfSpryker/Shared/CheckoutPage/CheckoutPageConstants.php
+++ b/src/FondOfSpryker/Shared/CheckoutPage/CheckoutPageConstants.php
@@ -4,16 +4,53 @@ namespace FondOfSpryker\Shared\CheckoutPage;
 
 interface CheckoutPageConstants
 {
+    /**
+     * @var string
+     */
     public const SHOW_REGION_FOR_CONTRIES = 'SHOW_REGION_FOR_CONTRIES';
+
+    /**
+     * @var string
+     */
     public const CHECKOUT_PAGE_FIRST_NAME_VALIDATION_MIN_LENGTH_COUNT = 'CHECKOUT_PAGE_FIRST_NAME_VALIDATION_MIN_LENGTH_COUNT';
+
+    /**
+     * @var string
+     */
     public const CHECKOUT_PAGE_LAST_NAME_VALIDATION_MIN_LENGTH_COUNT = 'CHECKOUT_PAGE_LAST_NAME_VALIDATION_MIN_LENGTH_COUNT';
+
+    /**
+     * @var string
+     */
     public const CHECKOUT_PAGE_DEFAULT_VALIDATION_MIN_LENGTH_COUNT = 'CHECKOUT_PAGE_DEFAULT_VALIDATION_MIN_LENGTH_COUNT';
+
+    /**
+     * @var string
+     */
     public const CHECKOUT_PAGE_PRIORITY_COUNTRIES_COM_STORE = 'CHECKOUT_PAGE_PRIORITY_COUNTRIES_COM_STORE';
 
+    /**
+     * @var string
+     */
     public const ROUTE_CHECKOUT_BILLING_ADDRESS = 'checkout-billing-address';
+
+    /**
+     * @var string
+     */
     public const ROUTE_CHECKOUT_SHIPPING_ADDRESS = 'checkout-shipping-address';
+
+    /**
+     * @var string
+     */
     public const ROUTE_CHECKOUT_REGION_BY_COUNTRY = 'checkout-region-by-country';
 
+    /**
+     * @var string
+     */
     public const DEFAULT_SHIPMENT_METHOD_ID = 'FOND_OF_SPRYKER:CHECKOUT_PAGE:DEFAULT_SHIPMENT_METHOD_ID';
+
+    /**
+     * @var int
+     */
     public const DEFAULT_SHIPMENT_METHOD_ID_VALUE = 1;
 }

--- a/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageConfig.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageConfig.php
@@ -7,6 +7,9 @@ use SprykerShop\Yves\CheckoutPage\CheckoutPageConfig as SprykerCheckoutPageConfi
 
 class CheckoutPageConfig extends SprykerCheckoutPageConfig
 {
+    /**
+     * @var string
+     */
     public const PAYMENT_METHOD_NAME_NO_PAYMENT = 'paid';
 
     /**
@@ -64,7 +67,7 @@ class CheckoutPageConfig extends SprykerCheckoutPageConfig
     {
         return $this->get(
             CheckoutPageConstants::DEFAULT_SHIPMENT_METHOD_ID,
-            CheckoutPageConstants::DEFAULT_SHIPMENT_METHOD_ID_VALUE
+            CheckoutPageConstants::DEFAULT_SHIPMENT_METHOD_ID_VALUE,
         );
     }
 }

--- a/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
@@ -6,6 +6,8 @@ use FondOfSpryker\Yves\CheckoutPage\Dependency\CheckoutStoreCountryDataProviderI
 use FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCountryBridge;
 use FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCustomerClientBridge;
 use FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCustomerClientInterface;
+use FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToProductCountryRestrictionCheckoutConnectorBridge;
+use FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface;
 use FondOfSpryker\Yves\CheckoutPage\Form\CheckoutBillingAddressCollectionForm;
 use FondOfSpryker\Yves\CheckoutPage\Form\CheckoutShippingAddressCollectionForm;
 use FondOfSpryker\Yves\CheckoutPage\Form\DataProvider\CheckoutBillingAddressFormDataProvider;
@@ -41,6 +43,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
     public const CLIENT_SALES = 'CLIENT_SALES';
     public const CLIENT_COUNTRY = 'CLIENT_COUNTRY';
     public const CLIENT_CUSTOMER = 'CLIENT_CUSTOMER';
+    public const CLIENT_PRODUCT_COUNTRY_RESTRICTION_CHECKOUT_CONNECTOR = 'CLIENT_PRODUCT_COUNTRY_RESTRICTION_CHECKOUT_CONNECTOR';
 
     /**
      * @param \Spryker\Yves\Kernel\Container $container
@@ -60,8 +63,38 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
         $container = $this->addCountryClient($container);
         $container = $this->extendPaymentMethodHandler($container);
         $container = $this->extendPaymentSubForms($container);
+        $container = $this->addProductCountryRestrictionCheckoutConnectorClient($container);
 
         return $container;
+    }
+
+    /**
+     * @param \Spryker\Yves\Kernel\Container $container
+     *
+     * @return \Spryker\Yves\Kernel\Container
+     */
+    protected function addProductCountryRestrictionCheckoutConnectorClient(Container $container): Container
+    {
+        $self = $this;
+
+        $container[static::CLIENT_PRODUCT_COUNTRY_RESTRICTION_CHECKOUT_CONNECTOR] = static function (Container $container) use ($self) {
+            return $self->getProductCountryRestrictionCheckoutConnectorClient($container);
+        };
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Yves\Kernel\Container $container
+     *
+     * @return \FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface
+     */
+    protected function getProductCountryRestrictionCheckoutConnectorClient(
+        Container $container
+    ): CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface {
+        return new CheckoutPageToProductCountryRestrictionCheckoutConnectorBridge(
+            $container->getLocator()->productCountryRestrictionCheckoutConnector()->client()
+        );
     }
 
     /**
@@ -220,6 +253,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
     {
         return new CheckoutStoreCountryDataProvider(
             $container[static::CLIENT_GLOSSARY_STORAGE],
+            $container[static::CLIENT_PRODUCT_COUNTRY_RESTRICTION_CHECKOUT_CONNECTOR],
             $this->getStore(),
             $this->getConfig()
         );

--- a/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
@@ -33,16 +33,49 @@ use SprykerShop\Yves\CustomerPage\Form\CheckoutAddressCollectionForm;
  */
 class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyProvider
 {
+    /**
+     * @var string
+     */
     public const BILLING_ADDRESS_STEP_SUB_FORM = 'BILLING_ADDRESS_STEP_SUB_FORM';
+
+    /**
+     * @var string
+     */
     public const BILLING_ADDRESS_FORM_DATA_PROVIDER = 'BILLING_ADDRESS_FORM_DATA_PROVIDER';
 
+    /**
+     * @var string
+     */
     public const SHIPPING_ADDRESS_STEP_SUB_FORM = 'SHIPPING_ADDRESS_STEP_SUB_FORM';
+
+    /**
+     * @var string
+     */
     public const SHIPPING_ADDRESS_FORM_DATA_PROVIDER = 'SHIPPING_ADDRESS_FORM_DATA_PROVIDER';
 
+    /**
+     * @var string
+     */
     public const CLIENT_PAYONE = 'CLIENT_PAYONE';
+
+    /**
+     * @var string
+     */
     public const CLIENT_SALES = 'CLIENT_SALES';
+
+    /**
+     * @var string
+     */
     public const CLIENT_COUNTRY = 'CLIENT_COUNTRY';
+
+    /**
+     * @var string
+     */
     public const CLIENT_CUSTOMER = 'CLIENT_CUSTOMER';
+
+    /**
+     * @var string
+     */
     public const CLIENT_PRODUCT_COUNTRY_RESTRICTION_CHECKOUT_CONNECTOR = 'CLIENT_PRODUCT_COUNTRY_RESTRICTION_CHECKOUT_CONNECTOR';
 
     /**
@@ -93,7 +126,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
         Container $container
     ): CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface {
         return new CheckoutPageToProductCountryRestrictionCheckoutConnectorBridge(
-            $container->getLocator()->productCountryRestrictionCheckoutConnector()->client()
+            $container->getLocator()->productCountryRestrictionCheckoutConnector()->client(),
         );
     }
 
@@ -182,7 +215,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
     }
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     protected function getAddressStepSubForms(): array
     {
@@ -240,7 +273,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
             $this->getCustomerClient($container),
             $this->getCountryClient($container),
             $this->getCheckoutStoreCountryProvider($container),
-            $this->getGiftCardItemsChecker()
+            $this->getGiftCardItemsChecker(),
         );
     }
 
@@ -255,7 +288,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
             $container[static::CLIENT_GLOSSARY_STORAGE],
             $container[static::CLIENT_PRODUCT_COUNTRY_RESTRICTION_CHECKOUT_CONNECTOR],
             $this->getStore(),
-            $this->getConfig()
+            $this->getConfig(),
         );
     }
 
@@ -308,7 +341,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
             $this->getCustomerClient($container),
             $this->getCountryClient($container),
             $this->getCheckoutStoreCountryProvider($container),
-            $this->getGiftCardItemsChecker()
+            $this->getGiftCardItemsChecker(),
         );
     }
 
@@ -345,7 +378,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
                 $handlerPluginCollection->add(new NopaymentHandlerPlugin(), NopaymentConfig::PAYMENT_PROVIDER_NAME);
 
                 return $handlerPluginCollection;
-            }
+            },
         );
 
         return $container;

--- a/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageFactory.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/CheckoutPageFactory.php
@@ -22,7 +22,7 @@ class CheckoutPageFactory extends SprykerShopCheckoutPageFactory
     public function createCheckoutProcess()
     {
         return $this->createStepFactory()->createStepEngine(
-            $this->createStepFactory()->createStepCollection()
+            $this->createStepFactory()->createStepCollection(),
         );
     }
 
@@ -51,7 +51,7 @@ class CheckoutPageFactory extends SprykerShopCheckoutPageFactory
     }
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     public function getCustomerPageWidgetPlugins(): array
     {

--- a/src/FondOfSpryker/Yves/CheckoutPage/Controller/CheckoutController.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Controller/CheckoutController.php
@@ -11,12 +11,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class CheckoutController extends SprykerShopCheckoutController
 {
+    /**
+     * @var string
+     */
     protected const PATTERN_CHECKOUT_BILLING_ADDRESS = '/^(\/[a-z]{2})?\/checkout\/billing-address(\/)?/';
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|array
      */
     public function indexAction(Request $request)
     {
@@ -34,7 +37,7 @@ class CheckoutController extends SprykerShopCheckoutController
             $request,
             $this->getFactory()
                 ->createCheckoutFormFactory()
-                ->createCustomerFormCollection()
+                ->createCustomerFormCollection(),
         );
 
         return $response;
@@ -51,7 +54,7 @@ class CheckoutController extends SprykerShopCheckoutController
             $request,
             $this->getFactory()
                 ->createCheckoutFormFactory()
-                ->createAddressFormCollection()
+                ->createAddressFormCollection(),
         );
 
         if (!is_array($response)) {
@@ -61,7 +64,7 @@ class CheckoutController extends SprykerShopCheckoutController
         return $this->view(
             $response,
             $this->getFactory()->getCustomerPageWidgetPlugins(),
-            '@CheckoutPage/views/address/address.twig'
+            '@CheckoutPage/views/address/address.twig',
         );
     }
 
@@ -79,7 +82,7 @@ class CheckoutController extends SprykerShopCheckoutController
             $request,
             $this->getFactory()
                 ->createCheckoutFormFactory()
-                ->createBillingAddressFormCollection()
+                ->createBillingAddressFormCollection(),
         );
 
         if (!is_array($response)) {
@@ -96,14 +99,14 @@ class CheckoutController extends SprykerShopCheckoutController
         return $this->view(
             $response,
             $this->getFactory()->getCustomerPageWidgetPlugins(),
-            '@CheckoutPage/views/billing-address/billing-address.twig'
+            '@CheckoutPage/views/billing-address/billing-address.twig',
         );
     }
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return array|\Spryker\Yves\Kernel\View\View|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return \Spryker\Yves\Kernel\View\View|\Symfony\Component\HttpFoundation\RedirectResponse|array
      */
     public function shippingAddressAction(Request $request)
     {
@@ -120,7 +123,7 @@ class CheckoutController extends SprykerShopCheckoutController
             $request,
             $this->getFactory()
                 ->createCheckoutFormFactory()
-                ->createShippingAddressFormCollection()
+                ->createShippingAddressFormCollection(),
         );
 
         if (!is_array($response)) {
@@ -130,7 +133,7 @@ class CheckoutController extends SprykerShopCheckoutController
         return $this->view(
             $response,
             [],
-            '@CheckoutPage/views/shipping-address/shipping-address.twig'
+            '@CheckoutPage/views/shipping-address/shipping-address.twig',
         );
     }
 
@@ -145,7 +148,7 @@ class CheckoutController extends SprykerShopCheckoutController
             $this->getFactory()->createEmptyPaymentMethodValidator()->validate($request),
             $this->getFactory()
                 ->createCheckoutFormFactory()
-                ->getPaymentFormCollection()
+                ->getPaymentFormCollection(),
         );
 
         if (!is_array($response)) {
@@ -155,7 +158,7 @@ class CheckoutController extends SprykerShopCheckoutController
         return $this->view(
             $response,
             $this->getFactory()->getCustomerPageWidgetPlugins(),
-            '@CheckoutPage/views/payment/payment.twig'
+            '@CheckoutPage/views/payment/payment.twig',
         );
     }
 
@@ -179,7 +182,7 @@ class CheckoutController extends SprykerShopCheckoutController
             $request,
             $this->getFactory()
                 ->createCheckoutFormFactory()
-                ->createSummaryFormCollection()
+                ->createSummaryFormCollection(),
         );
 
         if (!is_array($viewData)) {
@@ -198,7 +201,7 @@ class CheckoutController extends SprykerShopCheckoutController
         return $this->view(
             array_merge($viewData, ['taxInPercent' => $taxInPercent]),
             $this->getFactory()->getSummaryPageWidgetPlugins(),
-            '@CheckoutPage/views/summary/summary.twig'
+            '@CheckoutPage/views/summary/summary.twig',
         );
     }
 
@@ -215,7 +218,7 @@ class CheckoutController extends SprykerShopCheckoutController
         return $this->view(
             ['quoteTransfer' => $quoteTransfer],
             [],
-            '@CheckoutPage/views/order-fail/order-fail.twig'
+            '@CheckoutPage/views/order-fail/order-fail.twig',
         );
     }
 

--- a/src/FondOfSpryker/Yves/CheckoutPage/Dependency/CheckoutStoreCountryDataProviderInterface.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Dependency/CheckoutStoreCountryDataProviderInterface.php
@@ -2,10 +2,14 @@
 
 namespace FondOfSpryker\Yves\CheckoutPage\Dependency;
 
+use Generated\Shared\Transfer\QuoteTransfer;
+
 interface CheckoutStoreCountryDataProviderInterface
 {
     /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
      * @return array
      */
-    public function getCountries(): array;
+    public function getCountries(QuoteTransfer $quoteTransfer): array;
 }

--- a/src/FondOfSpryker/Yves/CheckoutPage/Dependency/Client/CheckoutPageToProductCountryRestrictionCheckoutConnectorBridge.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Dependency/Client/CheckoutPageToProductCountryRestrictionCheckoutConnectorBridge.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FondOfSpryker\Yves\CheckoutPage\Dependency\Client;
+
+use FondOfOryx\Client\ProductCountryRestrictionCheckoutConnector\ProductCountryRestrictionCheckoutConnectorClient;
+use Generated\Shared\Transfer\BlacklistedCountryCollectionTransfer;
+use Generated\Shared\Transfer\QuoteTransfer;
+
+class CheckoutPageToProductCountryRestrictionCheckoutConnectorBridge implements CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface
+{
+    /**
+     * @var \FondOfOryx\Client\ProductCountryRestrictionCheckoutConnector\ProductCountryRestrictionCheckoutConnectorClient
+     */
+    private $client;
+
+    /**
+     * @param \FondOfOryx\Client\ProductCountryRestrictionCheckoutConnector\ProductCountryRestrictionCheckoutConnectorClient $client
+     */
+    public function __construct(ProductCountryRestrictionCheckoutConnectorClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \Generated\Shared\Transfer\BlacklistedCountryTransfer
+     */
+    public function getBlacklistedCountryCollectionByQuote(QuoteTransfer $quoteTransfer): BlacklistedCountryCollectionTransfer
+    {
+        return $this->client->getBlacklistedCountryCollectionByQuote($quoteTransfer);
+    }
+}

--- a/src/FondOfSpryker/Yves/CheckoutPage/Dependency/Client/CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Dependency/Client/CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FondOfSpryker\Yves\CheckoutPage\Dependency\Client;
+
+use Generated\Shared\Transfer\BlacklistedCountryCollectionTransfer;
+use Generated\Shared\Transfer\QuoteTransfer;
+
+interface CheckoutPageToProductCountryRestrictionCheckoutConnectorInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \Generated\Shared\Transfer\BlacklistedCountryCollectionTransfer
+     */
+    public function getBlacklistedCountryCollectionByQuote(QuoteTransfer $quoteTransfer): BlacklistedCountryCollectionTransfer;
+}

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressCollectionForm.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressCollectionForm.php
@@ -19,18 +19,48 @@ use Symfony\Component\Validator\Constraint;
  */
 class CheckoutBillingAddressCollectionForm extends AbstractType
 {
+    /**
+     * @var string
+     */
     public const FIELD_SHIPPING_ADDRESS = 'shippingAddress';
+
+    /**
+     * @var string
+     */
     public const FIELD_BILLING_ADDRESS = 'billingAddress';
+
+    /**
+     * @var string
+     */
     public const FIELD_BILLING_SAME_AS_SHIPPING = 'billingSameAsShipping';
 
+    /**
+     * @var string
+     */
     public const OPTION_ADDRESS_CHOICES = 'address_choices';
+
+    /**
+     * @var string
+     */
     public const OPTION_COUNTRY_CHOICES = 'country_choices';
+
+    /**
+     * @var string
+     */
     public const OPTION_SALUTATIONS = 'salutations';
+
+    /**
+     * @var string
+     */
     public const OPTION_GIFT_CARD_ONLY_CARD = 'gift_card_only_card';
 
     public const GROUP_SHIPPING_ADDRESS = self::FIELD_SHIPPING_ADDRESS;
+
     public const GROUP_BILLING_ADDRESS = self::FIELD_BILLING_ADDRESS;
 
+    /**
+     * @var string
+     */
     public const COUNTRY_CLIENT = 'country_client';
 
     /**
@@ -48,7 +78,6 @@ class CheckoutBillingAddressCollectionForm extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        /** @var \Symfony\Component\OptionsResolver\OptionsResolver $resolver */
         $resolver->setDefaults([
             'validation_groups' => function (FormInterface $form) {
                 $validationGroups = [Constraint::DEFAULT_GROUP, static::GROUP_BILLING_ADDRESS];
@@ -103,7 +132,7 @@ class CheckoutBillingAddressCollectionForm extends AbstractType
         $builder->add(
             static::FIELD_BILLING_SAME_AS_SHIPPING,
             $fieldType,
-            $fieldOptions
+            $fieldOptions,
         );
 
         if ($options[CheckoutBillingAddressForm::OPTION_GIFT_CARD_ONLY_CARD] === true) {
@@ -112,7 +141,7 @@ class CheckoutBillingAddressCollectionForm extends AbstractType
                     return (string)$asBool;
                 }, function (?string $asString) {
                     return $asString === null ? true : (bool)$asString;
-                })
+                }),
             );
         }
 

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressForm.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressForm.php
@@ -304,10 +304,14 @@ class CheckoutBillingAddressForm extends AbstractType
             'choices_as_values' => true,
             'placeholder' => (count($options[self::OPTION_COUNTRY_CHOICES]) > 1) ? 'global.please_select' : false,
             'empty_data' => (count($options[self::OPTION_COUNTRY_CHOICES]) === 1) ? $selected : false,
+            'disabled' => true,
             'constraints' => [
                 $this->createNotBlankConstraint($options),
             ],
-            'attr' => ['autocomplete' => $this->formFieldNameMapper->mapFormFieldNameToAutocompletAttr(self::FIELD_ISO_2_CODE)],
+            'attr' => [
+                'disabled' => count($options[self::OPTION_COUNTRY_CHOICES]) === 1,
+                'autocomplete' => $this->formFieldNameMapper->mapFormFieldNameToAutocompletAttr(self::FIELD_ISO_2_CODE),
+            ],
         ]);
 
         return $this;
@@ -323,20 +327,6 @@ class CheckoutBillingAddressForm extends AbstractType
      */
     protected function addRegionField(FormBuilderInterface $builder, array $options)
     {
-        if (count($options[self::OPTION_COUNTRY_CHOICES]) === 1) {
-            $iso2code = ($builder->get(self::FIELD_ISO_2_CODE)->getData()
-                ?: current(array_flip($options[self::OPTION_COUNTRY_CHOICES])));
-
-            $builder->add(self::FIELD_REGION, ChoiceType::class, [
-                'required' => true,
-                'label' => 'customer.address.region',
-                'choices' => array_flip($this->getRegions($iso2code)),
-                'attr' => ['autocomplete' => $this->formFieldNameMapper->mapFormFieldNameToAutocompletAttr(self::FIELD_REGION)],
-            ]);
-
-            return $this;
-        }
-
         $formModifier = function (FormInterface $form, ?string $iso2code = null) {
             $showRegions = $this->getFactory()
                 ->getCheckoutPageConfig()

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressForm.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressForm.php
@@ -29,34 +29,129 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 class CheckoutBillingAddressForm extends AbstractType
 {
+    /**
+     * @var string
+     */
     public const FIELD_EMAIL = 'email';
+
+    /**
+     * @var string
+     */
     public const FIELD_SALUTATION = 'salutation';
+
+    /**
+     * @var string
+     */
     public const FIELD_FIRST_NAME = 'first_name';
+
+    /**
+     * @var string
+     */
     public const FIELD_LAST_NAME = 'last_name';
+
+    /**
+     * @var string
+     */
     public const FIELD_ADDRESS_1 = 'address1';
+
+    /**
+     * @var string
+     */
     public const FIELD_ADDRESS_2 = 'address2';
+
+    /**
+     * @var string
+     */
     public const FIELD_ADDRESS_3 = 'address3';
+
+    /**
+     * @var string
+     */
     public const FIELD_REGION = 'region';
+
+    /**
+     * @var string
+     */
     public const FIELD_PHONE = 'phone';
+
+    /**
+     * @var string
+     */
     public const FIELD_ZIP_CODE = 'zip_code';
+
+    /**
+     * @var string
+     */
     public const FIELD_CITY = 'city';
+
+    /**
+     * @var string
+     */
     public const FIELD_ISO_2_CODE = 'iso2_code';
+
+    /**
+     * @var string
+     */
     public const FIELD_ID_CUSTOMER_ADDRESS = 'id_customer_address';
+
+    /**
+     * @var string
+     */
     public const FIELD_SHOW_REGION = 'show_region';
+
+    /**
+     * @var string
+     */
     public const FIELD_HOUSE_NUMBER_VALIDATION = 'houseNumberValidation';
 
+    /**
+     * @var string
+     */
     public const OPTION_VALIDATION_GROUP = 'validation_group';
 
+    /**
+     * @var string
+     */
     public const OPTION_COUNTRY_CHOICES = 'country_choices';
+
+    /**
+     * @var string
+     */
     public const OPTION_ADDRESS_CHOICES = 'address_choices';
+
+    /**
+     * @var string
+     */
     public const OPTION_SALUTATIONS = 'salutations';
+
+    /**
+     * @var string
+     */
     public const OPTION_GIFT_CARD_ONLY_CARD = 'gift_card_only_card';
 
+    /**
+     * @var string
+     */
     protected const VALIDATION_NOT_BLANK_MESSAGE = 'validation.not_blank';
+
+    /**
+     * @var string
+     */
     protected const VALIDATION_MIN_LENGTH_MESSAGE = 'validation.min_length';
+
+    /**
+     * @var string
+     */
     protected const VALIDATE_REGEX_EMAIL = "/^[A-ZÄÖÜa-zäöü0-9._%+\&\-ß!]+@[a-zäöüA-ZÄÖÜ0-9.\-ß]+\.[a-zäöüA-ZÄÖÜ]{2,}$/ix";
 
+    /**
+     * @var string
+     */
     public const COUNTRY_CLIENT = 'country_client';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_PREFIX = 'billing';
 
     /**

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressForm.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutBillingAddressForm.php
@@ -304,7 +304,6 @@ class CheckoutBillingAddressForm extends AbstractType
             'choices_as_values' => true,
             'placeholder' => (count($options[self::OPTION_COUNTRY_CHOICES]) > 1) ? 'global.please_select' : false,
             'empty_data' => (count($options[self::OPTION_COUNTRY_CHOICES]) === 1) ? $selected : false,
-            'disabled' => true,
             'constraints' => [
                 $this->createNotBlankConstraint($options),
             ],

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutShippingAddressCollectionForm.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutShippingAddressCollectionForm.php
@@ -12,11 +12,31 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CheckoutShippingAddressCollectionForm extends AbstractType
 {
+    /**
+     * @var string
+     */
     public const FIELD_SHIPPING_ADDRESS = 'shippingAddress';
+
+    /**
+     * @var string
+     */
     public const OPTION_ADDRESS_CHOICES = 'address_choices';
+
+    /**
+     * @var string
+     */
     public const OPTION_COUNTRY_CHOICES = 'country_choices';
+
+    /**
+     * @var string
+     */
     public const OPTION_SALUTATION = 'salutations';
+
     public const GROUP_SHIPPING_ADDRESS = self::FIELD_SHIPPING_ADDRESS;
+
+    /**
+     * @var string
+     */
     public const COUNTRY_CLIENT = 'country_client';
 
     /**
@@ -34,7 +54,6 @@ class CheckoutShippingAddressCollectionForm extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        /** @var \Symfony\Component\OptionsResolver\OptionsResolver $resolver */
         $resolver->setDefaults([
             'validation_groups' => [self::GROUP_SHIPPING_ADDRESS],
             self::OPTION_ADDRESS_CHOICES => [],

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutShippingAddressForm.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/CheckoutShippingAddressForm.php
@@ -10,7 +10,9 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class CheckoutShippingAddressForm extends CheckoutBillingAddressForm
 {
-    public const FIELD_ADDITIONAL_ADDRESS = 'additional_address';
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_PREFIX = 'shipping';
 
     /**

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/DataProvider/CheckoutBillingAddressFormDataProvider.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/DataProvider/CheckoutBillingAddressFormDataProvider.php
@@ -77,7 +77,7 @@ class CheckoutBillingAddressFormDataProvider implements StepEngineFormDataProvid
     {
         return [
             CheckoutBillingAddressForm::OPTION_ADDRESS_CHOICES => $this->getAddressChoices(),
-            CheckoutBillingAddressForm::OPTION_COUNTRY_CHOICES => $this->getAvailableCountries(),
+            CheckoutBillingAddressForm::OPTION_COUNTRY_CHOICES => $this->getAvailableCountries($quoteTransfer),
             CheckoutBillingAddressForm::COUNTRY_CLIENT => $this->countryClient,
             CheckoutBillingAddressForm::OPTION_SALUTATIONS => $this->getSalutationOptions(),
             CheckoutBillingAddressForm::OPTION_GIFT_CARD_ONLY_CARD => $this->giftCardItemsChecker->hasOnlyGiftCardItems(
@@ -146,11 +146,13 @@ class CheckoutBillingAddressFormDataProvider implements StepEngineFormDataProvid
     }
 
     /**
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
      * @return array
      */
-    protected function getAvailableCountries(): array
+    protected function getAvailableCountries(QuoteTransfer $quoteTransfer): array
     {
-        return $this->countryDataProvider->getCountries();
+        return $this->countryDataProvider->getCountries($quoteTransfer);
     }
 
     /**

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/DataProvider/CheckoutBillingAddressFormDataProvider.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/DataProvider/CheckoutBillingAddressFormDataProvider.php
@@ -14,7 +14,14 @@ use SprykerShop\Yves\CheckoutPage\GiftCard\GiftCardItemsCheckerInterface;
 
 class CheckoutBillingAddressFormDataProvider implements StepEngineFormDataProviderInterface
 {
+    /**
+     * @var string
+     */
     public const OPTION_ADDRESS_CHOICES = 'address_choices';
+
+    /**
+     * @var string
+     */
     public const OPTION_COUNTRY_CHOICES = 'country_choices';
 
     /**
@@ -41,6 +48,7 @@ class CheckoutBillingAddressFormDataProvider implements StepEngineFormDataProvid
      * @param \FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCustomerClientBridge $customerClient
      * @param \FondOfSpryker\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCountryInterface $countryClient
      * @param \FondOfSpryker\Yves\CheckoutPage\Dependency\CheckoutStoreCountryDataProviderInterface $countryDataProvider
+     * @param \SprykerShop\Yves\CheckoutPage\GiftCard\GiftCardItemsCheckerInterface $giftCardItemsChecker
      */
     public function __construct(
         CheckoutPageToCustomerClientBridge $customerClient,
@@ -81,7 +89,7 @@ class CheckoutBillingAddressFormDataProvider implements StepEngineFormDataProvid
             CheckoutBillingAddressForm::COUNTRY_CLIENT => $this->countryClient,
             CheckoutBillingAddressForm::OPTION_SALUTATIONS => $this->getSalutationOptions(),
             CheckoutBillingAddressForm::OPTION_GIFT_CARD_ONLY_CARD => $this->giftCardItemsChecker->hasOnlyGiftCardItems(
-                $quoteTransfer->getItems()
+                $quoteTransfer->getItems(),
             ),
         ];
     }
@@ -138,7 +146,7 @@ class CheckoutBillingAddressFormDataProvider implements StepEngineFormDataProvid
                 $address->getAddress1(),
                 $address->getAddress2(),
                 $address->getZipCode(),
-                $address->getCity()
+                $address->getCity(),
             );
         }
 

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/DataProvider/CheckoutStoreCountryDataProvider.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/DataProvider/CheckoutStoreCountryDataProvider.php
@@ -90,7 +90,7 @@ class CheckoutStoreCountryDataProvider implements CheckoutStoreCountryDataProvid
         foreach ($priorityCountriesIso2Codes as $iso2Code) {
             $priorityCountries[$iso2Code] = $this->glossaryStorageClient->translate(
                 self::COUNTRY_GLOSSARY_PREFIX . $iso2Code,
-                $this->store->getCurrentLocale()
+                $this->store->getCurrentLocale(),
             );
 
             if (array_key_exists($iso2Code, $allCountries)) {
@@ -111,7 +111,7 @@ class CheckoutStoreCountryDataProvider implements CheckoutStoreCountryDataProvid
         foreach ($this->store->getCountries() as $iso2Code) {
             $countries[$iso2Code] = $this->glossaryStorageClient->translate(
                 self::COUNTRY_GLOSSARY_PREFIX . $iso2Code,
-                $this->store->getCurrentLocale()
+                $this->store->getCurrentLocale(),
             );
         }
 

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/FormFactory.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/FormFactory.php
@@ -23,7 +23,7 @@ class FormFactory extends SprykerShopFormFactory
         return new FormCollectionHandler(
             $formTypes,
             $this->getProvidedDependency(ApplicationConstants::FORM_FACTORY),
-            $dataProvider
+            $dataProvider,
         );
     }
 
@@ -36,7 +36,7 @@ class FormFactory extends SprykerShopFormFactory
     }
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     public function getCustomerFormTypes()
     {
@@ -44,7 +44,7 @@ class FormFactory extends SprykerShopFormFactory
     }
 
     /**
-     * @return \Symfony\Component\Form\FormTypeInterface[]
+     * @return array<\Symfony\Component\Form\FormTypeInterface>
      */
     public function getAddressFormTypes()
     {
@@ -58,7 +58,7 @@ class FormFactory extends SprykerShopFormFactory
     {
         return $this->createFormCollection(
             $this->getShippingAddressFormTypes(),
-            $this->getShippingAddressFormDataProvider()
+            $this->getShippingAddressFormDataProvider(),
         );
     }
 
@@ -85,7 +85,7 @@ class FormFactory extends SprykerShopFormFactory
     {
         return $this->createFormCollection(
             $this->getBillingAddressFormTypes(),
-            $this->getBillingAddressFormDataProvider()
+            $this->getBillingAddressFormDataProvider(),
         );
     }
 
@@ -125,7 +125,7 @@ class FormFactory extends SprykerShopFormFactory
     }
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     public function getSummaryFormTypes()
     {

--- a/src/FondOfSpryker/Yves/CheckoutPage/Form/Steps/PaymentForm.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Form/Steps/PaymentForm.php
@@ -30,14 +30,14 @@ class PaymentForm extends SprykerShopPaymentForm
                 'constraints' => [
                     new NotBlank(),
                 ],
-            ]
+            ],
         );
 
         return $this;
     }
 
     /**
-     * @param \Spryker\Yves\StepEngine\Dependency\Form\SubFormInterface[] $paymentMethodSubForms
+     * @param array<\Spryker\Yves\StepEngine\Dependency\Form\SubFormInterface> $paymentMethodSubForms
      *
      * @return array
      */

--- a/src/FondOfSpryker/Yves/CheckoutPage/Mapper/FormFieldNameMapper.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Mapper/FormFieldNameMapper.php
@@ -6,16 +6,59 @@ use FondOfSpryker\Yves\CheckoutPage\Form\CheckoutBillingAddressForm;
 
 class FormFieldNameMapper implements FormFieldNameMapperInterface
 {
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_EMAIL = 'email';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_SALUTATION = 'honorific-prefix';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_FIRST_NAME = 'given-name';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_LAST_NAME = 'family-name';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_ADDRESS_1 = 'address-line1';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_ADDRESS_2 = 'address-line2';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_ADDRESS_3 = 'address-line2';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_ZIP_CODE = 'postal-code';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_CITY = 'address-level2';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_ISO_2_CODE = 'country-name';
+
+    /**
+     * @var string
+     */
     public const AUTOCOMPLETE_ATTR_PHONE = 'tel';
 
     /**
@@ -23,6 +66,9 @@ class FormFieldNameMapper implements FormFieldNameMapperInterface
      */
     protected $prefix;
 
+    /**
+     * @var array
+     */
     public const ATTR = [
         CheckoutBillingAddressForm::FIELD_EMAIL => self::AUTOCOMPLETE_ATTR_EMAIL,
         CheckoutBillingAddressForm::FIELD_SALUTATION => self::AUTOCOMPLETE_ATTR_SALUTATION,

--- a/src/FondOfSpryker/Yves/CheckoutPage/Plugin/Provider/CheckoutPageControllerProvider.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Plugin/Provider/CheckoutPageControllerProvider.php
@@ -7,8 +7,19 @@ use SprykerShop\Yves\CheckoutPage\Plugin\Provider\CheckoutPageControllerProvider
 
 class CheckoutPageControllerProvider extends SprykerShopCheckoutPageControllerProvider
 {
+    /**
+     * @var string
+     */
     public const CHECKOUT_BILLING_ADDRESS = 'checkout-billing-address';
+
+    /**
+     * @var string
+     */
     public const CHECKOUT_SHIPPING_ADDRESS = 'checkout-shipping-address';
+
+    /**
+     * @var string
+     */
     public const CHECKOUT_REGION_BY_COUNTRY = 'checkout-region-by-country';
 
     /**

--- a/src/FondOfSpryker/Yves/CheckoutPage/Plugin/Router/CheckoutPageRouteProviderPlugin.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Plugin/Router/CheckoutPageRouteProviderPlugin.php
@@ -62,7 +62,7 @@ class CheckoutPageRouteProviderPlugin extends SprykerCheckoutPageRouteProviderPl
             '/checkout/region-by-country/{country}',
             'CheckoutPage',
             'Checkout',
-            'regionsByCountry'
+            'regionsByCountry',
         );
         $route
             ->setMethods(['GET'])

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/StepFactory.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/StepFactory.php
@@ -28,7 +28,7 @@ class StepFactory extends SprykerShopStepFactory
     {
         $stepCollection = new StepCollection(
             $this->getUrlGenerator(),
-            CheckoutPageControllerProvider::CHECKOUT_ERROR
+            CheckoutPageControllerProvider::CHECKOUT_ERROR,
         );
 
         $stepCollection
@@ -55,7 +55,7 @@ class StepFactory extends SprykerShopStepFactory
             $this->getCustomerStepHandler(),
             CheckoutPageControllerProvider::CHECKOUT_CUSTOMER,
             HomePageControllerProvider::ROUTE_HOME,
-            $this->getApplication()->path(HomePageControllerProvider::ROUTE_HOME)
+            $this->getApplication()->path(HomePageControllerProvider::ROUTE_HOME),
         );
     }
 
@@ -72,7 +72,7 @@ class StepFactory extends SprykerShopStepFactory
             $this->createAddressStepPostConditionChecker(),
             $this->getConfig(),
             $this->getCheckoutAddressStepEnterPreCheckPlugins(),
-            $this->createGiftCardItemsChecker()
+            $this->createGiftCardItemsChecker(),
         );
     }
 
@@ -89,7 +89,7 @@ class StepFactory extends SprykerShopStepFactory
             $this->createShipmentStepPostConditionChecker(),
             $this->getConfig(),
             $this->getCheckoutAddressStepEnterPreCheckPlugins(),
-            $this->createGiftCardItemsChecker()
+            $this->createGiftCardItemsChecker(),
         );
     }
 
@@ -106,7 +106,7 @@ class StepFactory extends SprykerShopStepFactory
             CheckoutPageControllerProvider::CHECKOUT_SHIPMENT,
             HomePageControllerProvider::ROUTE_HOME,
             $this->getCheckoutShipmentStepEnterPreCheckPlugins(),
-            $this->getConfig()
+            $this->getConfig(),
         );
     }
 
@@ -122,7 +122,7 @@ class StepFactory extends SprykerShopStepFactory
             $this->getConfig()->getEscapeRoute(),
             $this->getFlashMessenger(),
             $this->getCalculationClient(),
-            $this->getCheckoutPaymentStepEnterPreCheckPlugins()
+            $this->getCheckoutPaymentStepEnterPreCheckPlugins(),
         );
     }
 
@@ -141,7 +141,7 @@ class StepFactory extends SprykerShopStepFactory
             [
                 'payment failed' => CheckoutPageControllerProvider::CHECKOUT_PAYMENT,
                 'shipment failed' => CheckoutPageControllerProvider::CHECKOUT_SHIPMENT,
-            ]
+            ],
         );
     }
 
@@ -157,7 +157,7 @@ class StepFactory extends SprykerShopStepFactory
             $this->getPayoneClient(),
             $this->getSalesClient(),
             CheckoutPageControllerProvider::CHECKOUT_SUCCESS,
-            HomePageControllerProvider::ROUTE_HOME
+            HomePageControllerProvider::ROUTE_HOME,
         );
     }
 
@@ -193,7 +193,7 @@ class StepFactory extends SprykerShopStepFactory
         return new BillingAddressStepExecutor(
             $this->getCustomerService(),
             $this->getCustomerClient(),
-            $this->getShoppingListItemExpanderPlugins()
+            $this->getShoppingListItemExpanderPlugins(),
         );
     }
 
@@ -205,7 +205,7 @@ class StepFactory extends SprykerShopStepFactory
         return new ShippingAddressStepExecutor(
             $this->getCustomerService(),
             $this->getCustomerClient(),
-            $this->getShoppingListItemExpanderPlugins()
+            $this->getShoppingListItemExpanderPlugins(),
         );
     }
 }

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/StepFactory.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/StepFactory.php
@@ -13,6 +13,7 @@ use FondOfSpryker\Yves\CheckoutPage\Process\Steps\PlaceOrderStep;
 use FondOfSpryker\Yves\CheckoutPage\Process\Steps\ShipmentStep;
 use FondOfSpryker\Yves\CheckoutPage\Process\Steps\ShippingAddressStep;
 use FondOfSpryker\Yves\CheckoutPage\Process\Steps\SuccessStep;
+use Spryker\Shared\Log\LoggerTrait;
 use Spryker\Yves\StepEngine\Process\StepCollection;
 use SprykerShop\Yves\CheckoutPage\Process\StepFactory as SprykerShopStepFactory;
 use SprykerShop\Yves\CheckoutPage\Process\Steps\AbstractBaseStep;
@@ -21,6 +22,8 @@ use SprykerShop\Yves\HomePage\Plugin\Provider\HomePageControllerProvider;
 
 class StepFactory extends SprykerShopStepFactory
 {
+    use LoggerTrait;
+
     /**
      * @return \Spryker\Yves\StepEngine\Process\StepCollectionInterface
      */
@@ -123,6 +126,7 @@ class StepFactory extends SprykerShopStepFactory
             $this->getFlashMessenger(),
             $this->getCalculationClient(),
             $this->getCheckoutPaymentStepEnterPreCheckPlugins(),
+            $this->getLogger()
         );
     }
 

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/AddressStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/AddressStep.php
@@ -36,7 +36,7 @@ class AddressStep extends SprykerShopAddressStep
             $checkoutPageConfig,
             $stepRoute,
             $escapeRoute,
-            $checkoutAddressStepEnterPreCheckPlugins
+            $checkoutAddressStepEnterPreCheckPlugins,
         );
     }
 

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/AddressStep/ShippingAddressStepExecutor.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/AddressStep/ShippingAddressStepExecutor.php
@@ -102,7 +102,7 @@ class ShippingAddressStepExecutor extends SprykerAddressStepExecutor
 
             $shipmentTransfer = $this->getShipmentWithUniqueShippingAddress(
                 $shipmentTransfer,
-                $customerTransfer
+                $customerTransfer,
             );
             $itemTransfer->setShipment($shipmentTransfer);
         }

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/BillingAddressStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/BillingAddressStep.php
@@ -11,6 +11,9 @@ use SprykerShop\Yves\CheckoutPage\Process\Steps\StepExecutorInterface;
 
 class BillingAddressStep extends AddressStep
 {
+    /**
+     * @var string
+     */
     public const BREADCRUMB_ITEM_TITLE = 'checkout.step.billing-address.title';
 
     /**
@@ -25,7 +28,7 @@ class BillingAddressStep extends AddressStep
      * @param \SprykerShop\Yves\CheckoutPage\Process\Steps\StepExecutorInterface $stepExecutor
      * @param \SprykerShop\Yves\CheckoutPage\Process\Steps\PostConditionCheckerInterface $postConditionChecker
      * @param \SprykerShop\Yves\CheckoutPage\CheckoutPageConfig $checkoutPageConfig
-     * @param \SprykerShop\Yves\CheckoutPageExtension\Dependency\Plugin\CheckoutAddressStepEnterPreCheckPluginInterface[] $checkoutAddressStepEnterPreCheckPlugins
+     * @param array<\SprykerShop\Yves\CheckoutPageExtension\Dependency\Plugin\CheckoutAddressStepEnterPreCheckPluginInterface> $checkoutAddressStepEnterPreCheckPlugins
      * @param \SprykerShop\Yves\CheckoutPage\GiftCard\GiftCardItemsCheckerInterface $giftCardItemsChecker
      */
     public function __construct(
@@ -45,7 +48,7 @@ class BillingAddressStep extends AddressStep
             $stepExecutor,
             $postConditionChecker,
             $checkoutPageConfig,
-            $checkoutAddressStepEnterPreCheckPlugins
+            $checkoutAddressStepEnterPreCheckPlugins,
         );
 
         $this->giftCardItemsChecker = $giftCardItemsChecker;

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
@@ -37,8 +37,8 @@ class PaymentStep extends SprykerPaymentStep
         $this->getLogger()->notice(
             sprintf(
                 '[ORDER RESET] Order with reference %s has been reseted.',
-                $quoteTransfer->getOrderReference()
-            )
+                $quoteTransfer->getOrderReference(),
+            ),
         );
         $quoteTransfer->setCheckoutConfirmed(false);
         $quoteTransfer->setOrderReference(null);

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
@@ -9,7 +9,6 @@ use Spryker\Yves\Messenger\FlashMessenger\FlashMessengerInterface;
 use Spryker\Yves\StepEngine\Dependency\Plugin\Handler\StepHandlerPluginCollection;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface;
-use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractorInterface;
 use SprykerShop\Yves\CheckoutPage\Process\Steps\PaymentStep as SprykerPaymentStep;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -38,7 +37,6 @@ class PaymentStep extends SprykerPaymentStep
         FlashMessengerInterface $flashMessenger,
         CheckoutPageToCalculationClientInterface $calculationClient,
         array $checkoutPaymentStepEnterPreCheckPlugins,
-        PaymentMethodKeyExtractorInterface $paymentMethodKeyExtractor,
         LoggerInterface $logger
     ) {
         parent::__construct(
@@ -48,8 +46,7 @@ class PaymentStep extends SprykerPaymentStep
             $escapeRoute,
             $flashMessenger,
             $calculationClient,
-            $checkoutPaymentStepEnterPreCheckPlugins,
-            $paymentMethodKeyExtractor
+            $checkoutPaymentStepEnterPreCheckPlugins
         );
 
         $this->logger = $logger;

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
@@ -3,14 +3,54 @@
 namespace FondOfSpryker\Yves\CheckoutPage\Process\Steps;
 
 use Generated\Shared\Transfer\QuoteTransfer;
+use Psr\Log\LoggerInterface;
 use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
-use Spryker\Shared\Log\LoggerTrait;
+use Spryker\Yves\Messenger\FlashMessenger\FlashMessengerInterface;
+use Spryker\Yves\StepEngine\Dependency\Plugin\Handler\StepHandlerPluginCollection;
+use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface;
+use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface;
 use SprykerShop\Yves\CheckoutPage\Process\Steps\PaymentStep as SprykerPaymentStep;
 use Symfony\Component\HttpFoundation\Request;
 
 class PaymentStep extends SprykerPaymentStep
 {
-    use LoggerTrait;
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @param \SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface $paymentClient
+     * @param \Spryker\Yves\StepEngine\Dependency\Plugin\Handler\StepHandlerPluginCollection $paymentPlugins
+     * @param string $stepRoute
+     * @param string|null $escapeRoute
+     * @param \Spryker\Yves\Messenger\FlashMessenger\FlashMessengerInterface $flashMessenger
+     * @param \SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface $calculationClient
+     * @param \SprykerShop\Yves\CheckoutPageExtension\Dependency\Plugin\CheckoutPaymentStepEnterPreCheckPluginInterface[] $checkoutPaymentStepEnterPreCheckPlugins
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(
+        CheckoutPageToPaymentClientInterface $paymentClient,
+        StepHandlerPluginCollection $paymentPlugins,
+        string $stepRoute,
+        ?string $escapeRoute,
+        FlashMessengerInterface $flashMessenger,
+        CheckoutPageToCalculationClientInterface $calculationClient,
+        array $checkoutPaymentStepEnterPreCheckPlugins,
+        LoggerInterface $logger
+    ) {
+        parent::__construct(
+            $paymentClient,
+            $paymentPlugins,
+            $stepRoute,
+            $escapeRoute,
+            $flashMessenger,
+            $calculationClient,
+            $checkoutPaymentStepEnterPreCheckPlugins
+        );
+
+        $this->logger = $logger;
+    }
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
@@ -34,7 +74,7 @@ class PaymentStep extends SprykerPaymentStep
      */
     protected function resetOrderReference(QuoteTransfer $quoteTransfer): QuoteTransfer
     {
-        $this->getLogger()->notice(
+        $this->logger->notice(
             sprintf(
                 '[ORDER RESET] Order with reference %s has been reseted.',
                 $quoteTransfer->getOrderReference(),

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStep.php
@@ -9,6 +9,7 @@ use Spryker\Yves\Messenger\FlashMessenger\FlashMessengerInterface;
 use Spryker\Yves\StepEngine\Dependency\Plugin\Handler\StepHandlerPluginCollection;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface;
+use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractorInterface;
 use SprykerShop\Yves\CheckoutPage\Process\Steps\PaymentStep as SprykerPaymentStep;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -37,6 +38,7 @@ class PaymentStep extends SprykerPaymentStep
         FlashMessengerInterface $flashMessenger,
         CheckoutPageToCalculationClientInterface $calculationClient,
         array $checkoutPaymentStepEnterPreCheckPlugins,
+        PaymentMethodKeyExtractorInterface $paymentMethodKeyExtractor,
         LoggerInterface $logger
     ) {
         parent::__construct(
@@ -46,7 +48,8 @@ class PaymentStep extends SprykerPaymentStep
             $escapeRoute,
             $flashMessenger,
             $calculationClient,
-            $checkoutPaymentStepEnterPreCheckPlugins
+            $checkoutPaymentStepEnterPreCheckPlugins,
+            $paymentMethodKeyExtractor
         );
 
         $this->logger = $logger;

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/ShipmentStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/ShipmentStep.php
@@ -48,7 +48,7 @@ class ShipmentStep extends SprykerShopShipmentStep
             $giftCardItemsChecker,
             $stepRoute,
             $escapeRoute,
-            $checkoutShipmentStepEnterPreCheckPlugins
+            $checkoutShipmentStepEnterPreCheckPlugins,
         );
 
         $this->config = $config;

--- a/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/ShippingAddressStep.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Process/Steps/ShippingAddressStep.php
@@ -11,6 +11,9 @@ use SprykerShop\Yves\CheckoutPage\Process\Steps\StepExecutorInterface;
 
 class ShippingAddressStep extends AddressStep
 {
+    /**
+     * @var string
+     */
     public const BREADCRUMB_ITEM_TITLE = 'checkout.step.shipping-address.title';
 
     /**
@@ -25,7 +28,7 @@ class ShippingAddressStep extends AddressStep
      * @param \SprykerShop\Yves\CheckoutPage\Process\Steps\StepExecutorInterface $stepExecutor
      * @param \SprykerShop\Yves\CheckoutPage\Process\Steps\PostConditionCheckerInterface $postConditionChecker
      * @param \SprykerShop\Yves\CheckoutPage\CheckoutPageConfig $checkoutPageConfig
-     * @param \SprykerShop\Yves\CheckoutPageExtension\Dependency\Plugin\CheckoutAddressStepEnterPreCheckPluginInterface[] $checkoutAddressStepEnterPreCheckPlugins
+     * @param array<\SprykerShop\Yves\CheckoutPageExtension\Dependency\Plugin\CheckoutAddressStepEnterPreCheckPluginInterface> $checkoutAddressStepEnterPreCheckPlugins
      * @param \SprykerShop\Yves\CheckoutPage\GiftCard\GiftCardItemsCheckerInterface $giftCardItemsChecker
      */
     public function __construct(
@@ -45,7 +48,7 @@ class ShippingAddressStep extends AddressStep
             $stepExecutor,
             $postConditionChecker,
             $checkoutPageConfig,
-            $checkoutAddressStepEnterPreCheckPlugins
+            $checkoutAddressStepEnterPreCheckPlugins,
         );
 
         $this->giftCardItemsChecker = $giftCardItemsChecker;

--- a/src/FondOfSpryker/Yves/CheckoutPage/Validator/EmptyPaymentMethodValidator.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Validator/EmptyPaymentMethodValidator.php
@@ -6,8 +6,14 @@ use Symfony\Component\HttpFoundation\Request;
 
 class EmptyPaymentMethodValidator implements RequestValidatorInterface
 {
+    /**
+     * @var string
+     */
     protected const PAYMENT_FORM_NAME = 'paymentForm';
 
+    /**
+     * @var string
+     */
     protected const PAYMENT_FORM_SELECTION_NAME = 'paymentSelection';
 
     /**

--- a/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
+++ b/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
@@ -14,6 +14,8 @@ use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationCli
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientBridge;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface;
+use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractor;
+use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractorInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class PaymentStepTest extends Unit
@@ -39,6 +41,11 @@ class PaymentStepTest extends Unit
     private $paymentStep;
 
     /**
+     * @var \SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractor|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $paymentMethodKeyExtractorMock;
+
+    /**
      * @return void
      */
     protected function _before(): void
@@ -59,6 +66,10 @@ class PaymentStepTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->paymentMethodKeyExtractorMock = $this->getMockBuilder(PaymentMethodKeyExtractor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->paymentStep = new class (
             $paymentClientMock,
             $paymentMethodHandlerMocker,
@@ -67,6 +78,7 @@ class PaymentStepTest extends Unit
             $flashMessagenerMock,
             $calculationClientMock,
             [],
+            $this->paymentMethodKeyExtractorMock,
             $this->loggerMock
 ) extends PaymentStep {
 
@@ -95,6 +107,7 @@ class PaymentStepTest extends Unit
                 FlashMessengerInterface $flashMessenger,
                 CheckoutPageToCalculationClientInterface $calculationClient,
                 array $checkoutPaymentStepEnterPreCheckPlugins,
+                PaymentMethodKeyExtractorInterface $extractor,
                 LoggerInterface $loggerMock
             ) {
                 parent::__construct(
@@ -104,7 +117,8 @@ class PaymentStepTest extends Unit
                     $escapeRoute,
                     $flashMessenger,
                     $calculationClient,
-                    $checkoutPaymentStepEnterPreCheckPlugins
+                    $checkoutPaymentStepEnterPreCheckPlugins,
+                    $extractor
                 );
                 $this->loggerMock = $loggerMock;
             }

--- a/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
+++ b/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
@@ -82,9 +82,6 @@ class PaymentStepTest extends Unit
             $this->paymentMethodKeyExtractorMock,
             $this->loggerMock
 ) extends PaymentStep {
-
-            use LoggerTrait;
-
             /**
              * @var \Psr\Log\LoggerInterface
              */
@@ -124,16 +121,6 @@ class PaymentStepTest extends Unit
                     $extractor
                 );
                 $this->loggerMock = $loggerMock;
-            }
-
-            /**
-             * @param \Spryker\Shared\Log\Config\LoggerConfigInterface|null $loggerConfig
-             *
-             * @return \Psr\Log\LoggerInterface|null
-             */
-            protected function getLogger(?LoggerConfigInterface $loggerConfig = null)
-            {
-                return $this->loggerMock;
             }
         };
     }

--- a/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
+++ b/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
@@ -6,7 +6,6 @@ use Codeception\Test\Unit;
 use Generated\Shared\Transfer\QuoteTransfer;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
-use Spryker\Shared\Log\Config\LoggerConfigInterface;
 use Spryker\Yves\Messenger\FlashMessenger\FlashMessenger;
 use Spryker\Yves\Messenger\FlashMessenger\FlashMessengerInterface;
 use Spryker\Yves\StepEngine\Dependency\Plugin\Handler\StepHandlerPluginCollection;
@@ -14,20 +13,17 @@ use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationCli
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientBridge;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface;
-use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractor;
-use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractorInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Spryker\Shared\Log\LoggerTrait;
 
 class PaymentStepTest extends Unit
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\QuoteTransfer
      */
     private $quoteTransferMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\HttpFoundation\Request
      */
     private $requestMock;
 
@@ -40,11 +36,6 @@ class PaymentStepTest extends Unit
      * @var \FondOfSpryker\Yves\CheckoutPage\Process\Steps\PaymentStep
      */
     private $paymentStep;
-
-    /**
-     * @var \SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractor|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $paymentMethodKeyExtractorMock;
 
     /**
      * @return void
@@ -67,10 +58,6 @@ class PaymentStepTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->paymentMethodKeyExtractorMock = $this->getMockBuilder(PaymentMethodKeyExtractor::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->paymentStep = new class (
             $paymentClientMock,
             $paymentMethodHandlerMocker,
@@ -79,7 +66,6 @@ class PaymentStepTest extends Unit
             $flashMessagenerMock,
             $calculationClientMock,
             [],
-            $this->paymentMethodKeyExtractorMock,
             $this->loggerMock
 ) extends PaymentStep {
             /**
@@ -107,7 +93,6 @@ class PaymentStepTest extends Unit
                 FlashMessengerInterface $flashMessenger,
                 CheckoutPageToCalculationClientInterface $calculationClient,
                 array $checkoutPaymentStepEnterPreCheckPlugins,
-                PaymentMethodKeyExtractorInterface $extractor,
                 LoggerInterface $loggerMock
             ) {
                 parent::__construct(
@@ -118,7 +103,7 @@ class PaymentStepTest extends Unit
                     $flashMessenger,
                     $calculationClient,
                     $checkoutPaymentStepEnterPreCheckPlugins,
-                    $extractor
+                    $loggerMock
                 );
                 $this->loggerMock = $loggerMock;
             }

--- a/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
+++ b/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
@@ -17,6 +17,7 @@ use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientI
 use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractor;
 use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractorInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Spryker\Shared\Log\LoggerTrait;
 
 class PaymentStepTest extends Unit
 {
@@ -81,6 +82,8 @@ class PaymentStepTest extends Unit
             $this->paymentMethodKeyExtractorMock,
             $this->loggerMock
 ) extends PaymentStep {
+
+            use LoggerTrait;
 
             /**
              * @var \Psr\Log\LoggerInterface

--- a/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
+++ b/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
@@ -13,6 +13,8 @@ use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationCli
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientBridge;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface;
+use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractor;
+use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractorInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class PaymentStepTest extends Unit
@@ -31,6 +33,11 @@ class PaymentStepTest extends Unit
      * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $loggerMock;
+
+    /**
+     * @var PaymentMethodKeyExtractor|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $paymentMethodKeyExtractorMock;
 
     /**
      * @var \FondOfSpryker\Yves\CheckoutPage\Process\Steps\PaymentStep
@@ -57,6 +64,9 @@ class PaymentStepTest extends Unit
         $calculationClientMock = $this->getMockBuilder(CheckoutPageToCalculationClientBridge::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->paymentMethodKeyExtractorMock = $this->getMockBuilder(PaymentMethodKeyExtractor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->paymentStep = new class (
             $paymentClientMock,
@@ -66,6 +76,7 @@ class PaymentStepTest extends Unit
             $flashMessagenerMock,
             $calculationClientMock,
             [],
+            $this->paymentMethodKeyExtractorMock,
             $this->loggerMock
 ) extends PaymentStep {
             /**
@@ -83,6 +94,7 @@ class PaymentStepTest extends Unit
              * @param \Spryker\Yves\Messenger\FlashMessenger\FlashMessengerInterface $flashMessenger
              * @param \SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface $calculationClient
              * @param array $checkoutPaymentStepEnterPreCheckPlugins
+             * @param PaymentMethodKeyExtractorInterface $paymentMethodKeyExtractor
              * @param \Psr\Log\LoggerInterface $loggerMock
              */
             public function __construct(
@@ -93,6 +105,7 @@ class PaymentStepTest extends Unit
                 FlashMessengerInterface $flashMessenger,
                 CheckoutPageToCalculationClientInterface $calculationClient,
                 array $checkoutPaymentStepEnterPreCheckPlugins,
+                PaymentMethodKeyExtractorInterface $paymentMethodKeyExtractor,
                 LoggerInterface $loggerMock
             ) {
                 parent::__construct(
@@ -103,6 +116,7 @@ class PaymentStepTest extends Unit
                     $flashMessenger,
                     $calculationClient,
                     $checkoutPaymentStepEnterPreCheckPlugins,
+                    $paymentMethodKeyExtractor,
                     $loggerMock
                 );
             }

--- a/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
+++ b/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
@@ -105,7 +105,6 @@ class PaymentStepTest extends Unit
                     $checkoutPaymentStepEnterPreCheckPlugins,
                     $loggerMock
                 );
-                $this->loggerMock = $loggerMock;
             }
         };
     }

--- a/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
+++ b/tests/FondOfSpryker/Yves/CheckoutPage/Process/Steps/PaymentStepTest.php
@@ -13,8 +13,6 @@ use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationCli
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientBridge;
 use SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToPaymentClientInterface;
-use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractor;
-use SprykerShop\Yves\CheckoutPage\Extractor\PaymentMethodKeyExtractorInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class PaymentStepTest extends Unit
@@ -33,11 +31,6 @@ class PaymentStepTest extends Unit
      * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $loggerMock;
-
-    /**
-     * @var PaymentMethodKeyExtractor|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $paymentMethodKeyExtractorMock;
 
     /**
      * @var \FondOfSpryker\Yves\CheckoutPage\Process\Steps\PaymentStep
@@ -64,9 +57,6 @@ class PaymentStepTest extends Unit
         $calculationClientMock = $this->getMockBuilder(CheckoutPageToCalculationClientBridge::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->paymentMethodKeyExtractorMock = $this->getMockBuilder(PaymentMethodKeyExtractor::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $this->paymentStep = new class (
             $paymentClientMock,
@@ -76,7 +66,6 @@ class PaymentStepTest extends Unit
             $flashMessagenerMock,
             $calculationClientMock,
             [],
-            $this->paymentMethodKeyExtractorMock,
             $this->loggerMock
 ) extends PaymentStep {
             /**
@@ -94,7 +83,6 @@ class PaymentStepTest extends Unit
              * @param \Spryker\Yves\Messenger\FlashMessenger\FlashMessengerInterface $flashMessenger
              * @param \SprykerShop\Yves\CheckoutPage\Dependency\Client\CheckoutPageToCalculationClientInterface $calculationClient
              * @param array $checkoutPaymentStepEnterPreCheckPlugins
-             * @param PaymentMethodKeyExtractorInterface $paymentMethodKeyExtractor
              * @param \Psr\Log\LoggerInterface $loggerMock
              */
             public function __construct(
@@ -105,7 +93,6 @@ class PaymentStepTest extends Unit
                 FlashMessengerInterface $flashMessenger,
                 CheckoutPageToCalculationClientInterface $calculationClient,
                 array $checkoutPaymentStepEnterPreCheckPlugins,
-                PaymentMethodKeyExtractorInterface $paymentMethodKeyExtractor,
                 LoggerInterface $loggerMock
             ) {
                 parent::__construct(
@@ -116,7 +103,6 @@ class PaymentStepTest extends Unit
                     $flashMessenger,
                     $calculationClient,
                     $checkoutPaymentStepEnterPreCheckPlugins,
-                    $paymentMethodKeyExtractor,
                     $loggerMock
                 );
             }


### PR DESCRIPTION
**Description**

Consider country restrictions of quote-items, remove blacklisted-countries from country-seletion (billing- and shipping-address). if only one country is available, select field is also disabled.

![image](https://user-images.githubusercontent.com/35733274/182374195-9a63f4fe-65d8-4324-a6d0-9eca1aea0de5.png)


