### PR TITLE
✨symfony 5 compatibility

### DIFF
--- a/src/FondOfSpryker/Yves/CheckoutPage/Validator/EmptyPaymentMethodValidator.php
+++ b/src/FondOfSpryker/Yves/CheckoutPage/Validator/EmptyPaymentMethodValidator.php
@@ -25,7 +25,7 @@ class EmptyPaymentMethodValidator implements RequestValidatorInterface
     {
         if ($request->request->has(static::PAYMENT_FORM_NAME)) {
             //ToDo validate if formData really is an array
-            $formData = $request->request->get(static::PAYMENT_FORM_NAME);
+            $formData = $request->get(static::PAYMENT_FORM_NAME);
 
             if (
                 $formData !== null && // @phpstan-ignore-line


### PR DESCRIPTION
**Description:**

$request->request->get('xy') obsolete, use $request->get('xy') instead (should backward compatibile)